### PR TITLE
Fix `basic/install.bash` bug

### DIFF
--- a/basic/install.sh
+++ b/basic/install.sh
@@ -6,10 +6,10 @@
 _rofi="$HOME/.config/rofi"
 _theme="$HOME/.local/share/rofi/themes"
 
-if [[ ! -d "$_rofi" && ! -d "$_theme" ]]; then
+if [[ ! -d "$_rofi" || ! -d "$_theme" ]]; then
     mkdir -p "$_rofi" "$_theme"
 else
-    mkdir "$_rofi/userconfig/"
+    mkdir -p "$_rofi/userconfig/"
     mv "$_rofi/config.rasi" "$_rofi/userconfig/"
 fi
 


### PR DESCRIPTION
when $HOME/.config/rofi is exists, script is jump to else block(false && true = false) so we must use or in here and this is fix those problem

```diff
+if [[ ! -d "$_rofi" || ! -d "$_theme" ]]; then
     mkdir -p "$_rofi" "$_theme"
```