### PR TITLE
Fix wrong colors in macchiato basic theme for `button selected`

### DIFF
--- a/basic/.local/share/rofi/themes/catppuccin-macchiato.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-macchiato.rasi
@@ -92,6 +92,6 @@ button {
 }
 
 button selected {
-  background-color: @blue;
-  text-color: @fg-col;
+  background-color: @bg-col;
+  text-color: @blue;
 }


### PR DESCRIPTION
The colors defined in the macchiato basic theme for `button selected` seem to be incorrect. The other variants use:
```css
button selected {
    background-color: @bg-col;
    text-color: @blue;
}
```
while the macchiato variant uses:
```css
button selected {
    background-color: @blue;
    text-color: @fg-col;
}
```
which makes it difficult to read:

![2022-10-15_14-14](https://user-images.githubusercontent.com/56017218/195972426-f2632f7d-fef0-4c6e-8789-bdd52f551d15.png)

This PR makes the macchiato variant follow suit with the other variants.