### PR TITLE
feat: style `message` and `textbox` for basic theme

### DIFF
--- a/basic/.local/share/rofi/themes/catppuccin-frappe.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-frappe.rasi
@@ -95,3 +95,17 @@ button selected {
   background-color: @bg-col;
   text-color: @blue;
 }
+
+message {
+    background-color: @bg-col-light;
+    margin: 2px;
+    padding: 2px;
+    border-radius: 5px;
+}
+
+textbox {
+    padding: 6px;
+    margin: 20px 0px 0px 20px;
+    text-color: @blue;
+    background-color: @bg-col-light;
+}

--- a/basic/.local/share/rofi/themes/catppuccin-latte.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-latte.rasi
@@ -96,3 +96,16 @@ button selected {
   text-color: @blue;
 }
 
+message {
+    background-color: @bg-col-light;
+    margin: 2px;
+    padding: 2px;
+    border-radius: 5px;
+}
+
+textbox {
+    padding: 6px;
+    margin: 20px 0px 0px 20px;
+    text-color: @blue;
+    background-color: @bg-col-light;
+}

--- a/basic/.local/share/rofi/themes/catppuccin-macchiato.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-macchiato.rasi
@@ -95,3 +95,17 @@ button selected {
   background-color: @bg-col;
   text-color: @blue;
 }
+
+message {
+    background-color: @bg-col-light;
+    margin: 2px;
+    padding: 2px;
+    border-radius: 5px;
+}
+
+textbox {
+    padding: 6px;
+    margin: 20px 0px 0px 20px;
+    text-color: @blue;
+    background-color: @bg-col-light;
+}

--- a/basic/.local/share/rofi/themes/catppuccin-mocha.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-mocha.rasi
@@ -96,3 +96,16 @@ button selected {
   text-color: @blue;
 }
 
+message {
+    background-color: @bg-col-light;
+    margin: 2px;
+    padding: 2px;
+    border-radius: 5px;
+}
+
+textbox {
+    padding: 6px;
+    margin: 20px 0px 0px 20px;
+    text-color: @blue;
+    background-color: @bg-col-light;
+}


### PR DESCRIPTION
This PR fixes the padding and colour of Rofi's message box in the basic theme. The message box wasn't styled at all previously, probably because it's fairly rarely used, but some uses of Rofi rely on it.