### PR TITLE
fix(basic-config): update nerdfont symbols

### DIFF
--- a/basic/.config/rofi/config.rasi
+++ b/basic/.config/rofi/config.rasi
@@ -9,7 +9,7 @@ configuration{
     hide-scrollbar: true;
     display-drun: "   Apps ";
     display-run: "   Run ";
-    display-window: "󰕰  Window";
+    display-window: " 󰕰  Window";
     display-Network: " 󰤨  Network";
     sidebar-mode: true;
 }

--- a/basic/.config/rofi/config.rasi
+++ b/basic/.config/rofi/config.rasi
@@ -9,7 +9,7 @@ configuration{
     hide-scrollbar: true;
     display-drun: "   Apps ";
     display-run: "   Run ";
-    display-window: " 﩯  Window";
+    display-window: "󰕰  Window";
     display-Network: " 󰤨  Network";
     sidebar-mode: true;
 }


### PR DESCRIPTION
This is a simple fix to address a broken codepoint in the basic config. This is the fix I mentioned in issue #23 