### PR TITLE
build: use whiskers

### DIFF
--- a/basic/.local/share/rofi/themes/catppuccin-frappe.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-frappe.rasi
@@ -87,7 +87,7 @@ button {
     padding: 10px;
     background-color: @bg-col-light;
     text-color: @grey;
-    vertical-align: 0.5; 
+    vertical-align: 0.5;
     horizontal-align: 0.5;
 }
 

--- a/basic/.local/share/rofi/themes/catppuccin-latte.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-latte.rasi
@@ -87,7 +87,7 @@ button {
     padding: 10px;
     background-color: @bg-col-light;
     text-color: @grey;
-    vertical-align: 0.5; 
+    vertical-align: 0.5;
     horizontal-align: 0.5;
 }
 

--- a/basic/.local/share/rofi/themes/catppuccin-mocha.rasi
+++ b/basic/.local/share/rofi/themes/catppuccin-mocha.rasi
@@ -87,7 +87,7 @@ button {
     padding: 10px;
     background-color: @bg-col-light;
     text-color: @grey;
-    vertical-align: 0.5; 
+    vertical-align: 0.5;
     horizontal-align: 0.5;
 }
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers rofi.tera

--- a/rofi.tera
+++ b/rofi.tera
@@ -1,12 +1,19 @@
+---
+whiskers:
+  version: 2.4.0
+  matrix:
+    - flavor
+  filename: "basic/.local/share/rofi/themes/catppuccin-{{ flavor.identifier }}.rasi"
+---
 * {
-    bg-col:  #24273a;
-    bg-col-light: #24273a;
-    border-col: #24273a;
-    selected-col: #24273a;
-    blue: #8aadf4;
-    fg-col: #cad3f5;
-    fg-col2: #ed8796;
-    grey: #6e738d;
+    bg-col:  #{{ base.hex }};
+    bg-col-light: #{{ base.hex }};
+    border-col: #{{ base.hex }};
+    selected-col: #{{ base.hex }};
+    blue: #{{ blue.hex }};
+    fg-col: #{{ text.hex }};
+    fg-col2: #{{ red.hex }};
+    grey: #{{ overlay0.hex }};
 
     width: 600;
     font: "JetBrainsMono Nerd Font 14";


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's in-house templating tool, to build the themes. Edit the `rofi.tera` file and then run `just build` (or `whiskers rofi.tera`) to build the output themes for the `basic` config. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.
