### PR TITLE
Fix: #26 by removing the launcher close line, making it the default, escape

### DIFF
--- a/deathemonic/bin/launcher
+++ b/deathemonic/bin/launcher
@@ -7,5 +7,4 @@ rofi \
 	-drun-display-format "{name}" \
 	-no-drun-show-actions \
 	-terminal kitty \
-	-kb-cancel Alt-F1 \
 	-theme "$HOME"/.config/rofi/config/launcher.rasi


### PR DESCRIPTION
Removes an inconsistency within the launcher and runner files. They now both get canceled with the default escape key.